### PR TITLE
Add blog post for v1.7

### DIFF
--- a/_posts/2025-02-06-version-1-7.md
+++ b/_posts/2025-02-06-version-1-7.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: News in 1.7.0
+subtitle: Two new datasets, link health checker slightly improved
+gh-repo: fkie-cad/COMIDDS
+gh-badge: [star, fork, follow]
+tags: [datasets, features]
+comments: true
+author: Philipp Bönninghausen
+---
+
+TL;DR:
+- Two new datasets
+- A couple of dead links updated
+- Improved link health checker
+
+With nearly all major datasets now having been added to COMIDDS, the task of adding more of them has comfortably settled in the "Someday" category of my to-do list.
+Still, it can't remain there forever, lest the promised update frequency of "months" turns into "years".
+While at it, I also slightly improved the link health checker to now use a "proper" header (instead of the generic one used by Python's requests) to lessen the likelihood of getting undesired server responses.
+The Kyoto Honeypot dataset as well as the LID-DS dataset are currently experiencing issues / cannot be accessed, but at the time of creating this update, the issue has not been resolved.
+
+New dataset entries:
+- [IDEA Dataset](/COMIDDS/content/datasets/idea_2020)
+- [Biblio-US17](/COMIDDS/content/datasets/biblio_us17)


### PR DESCRIPTION
Release notes boil down to:

New datasets:
- Biblio-US17
- IDEA dataset

Other changes:
- Improved link health checker
- Updated some dead links