### PR TITLE
Add link to PCAP filter rules for the CSE-CIC-IDS2018 dataset

### DIFF
--- a/content/datasets/cse_cic_ids2018.md
+++ b/content/datasets/cse_cic_ids2018.md
@@ -87,6 +87,7 @@ The aforementioned flaws of this dataset, such as some simulation artifacts maki
       your AWS region and destination-dir is the target directory.
     - If cou only need the labeled features, use `s3://cse-cic-ids2018/Processed Traffic Data for ML Algorithms` as your URL
 - [Secondary Source](https://registry.opendata.aws/cse-cic-ids2018/)
+- [PCAP Filter Rules](https://github.com/UHH-ISS/rt-kcsm/tree/main/code/filter/cse-cic-ids2018/filters) derived from [[2]](https://intrusion-detection.distrinet-research.be/CNS2022/CSECICIDS2018.html)
 
 ### Related Entries
 - [CIC IDS2017](/COMIDDS/content/datasets/cic_ids2017)


### PR DESCRIPTION
For our paper, we evaluated our approach on the CSE-CIC-IDS2018 dataset, where we needed to generate our alerts by running the PCAP files through Suricata. To tag the alerts, we created filter rules based on the helpful work _[Liu et al. (2022): Error Prevalence in NIDS datasets: A Case Study on CIC-IDS-2017 and CSE-CIC-IDS-2018, CNS.](https://intrusion-detection.distrinet-research.be/CNS2022/CSECICIDS2018.html)_ that can be used by `tshark`. This ruleset may be useful for other researchers who want to work directly with PCAP files.